### PR TITLE
Regexp groups less eager: support multiple links

### DIFF
--- a/docs-gen/project/AkkaSamplePlugin.scala
+++ b/docs-gen/project/AkkaSamplePlugin.scala
@@ -34,13 +34,14 @@ object AkkaSamplePlugin extends sbt.AutoPlugin {
                      |=======================
                      |
                      |""".stripMargin,
-    bodyTransformation := { case s =>
-      val r = """\[(.+)\]\(src/(.+)\)""".r
-      val lines0 = s.split('\n').toList
-      val lines = lines0 map { line =>
-        r.replaceAllIn(line, """\[$1\]\(""" + baseUrl.value + "/" + baseProject.value + """/src/$2\)""")
-      }
-      lines.mkString("\n")
+    bodyTransformation := { case body =>
+      val r = """\[([^]]+)\]\(([^)]+)\)""".r
+      r.replaceAllIn(body,
+        _ match {
+          case r(lbl, uri) if !uri.contains("http") => s"""[$lbl](${baseUrl.value}/${baseProject.value}/$uri)"""
+          case r(lbl, uri) => s"[$lbl]($uri)"
+        }
+      )
     },
     templateName := baseProject.value.replaceAll("-sample-", "-samples-")
   )


### PR DESCRIPTION
Previous regular expression detecting links was too eager capturing the contents inside the parens (`()`)  causing the `replaceAllIn` to effectively replace only the last occurrence in a String. With this regexp all links in a string are captured.

With that change we don't need to split the body `s` into lines just to recompose it back.