### PR TITLE
Updated Scala and Java PersistenceActorExample examples to simplify

### DIFF
--- a/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentActorExample.java
+++ b/akka-sample-persistence-java/src/main/java/sample/persistence/PersistentActorExample.java
@@ -97,13 +97,10 @@ class ExamplePersistentActor extends AbstractPersistentActor {
         return receiveBuilder()
             .match(Cmd.class, c -> {
                 final String data = c.getData();
-                final Evt evt1 = new Evt(data + "-" + getNumEvents());
-                final Evt evt2 = new Evt(data + "-" + (getNumEvents() + 1));
-                persistAll(asList(evt1, evt2), (Evt evt) -> {
-                    state.update(evt);
-                    if (evt.equals(evt2)) {
-                        getContext().system().eventStream().publish(evt);
-                    }
+                final Evt evt = new Evt(data + "-" + getNumEvents());
+                persist(evt, (Evt event) -> {
+                    state.update(event);
+                    getContext().system().eventStream().publish(event);
                 });
             })
             .matchEquals("snap", s -> saveSnapshot(state.copy()))

--- a/akka-sample-persistence-scala/src/main/scala/sample/persistence/PersistentActorExample.scala
+++ b/akka-sample-persistence-scala/src/main/scala/sample/persistence/PersistentActorExample.scala
@@ -31,8 +31,7 @@ class ExamplePersistentActor extends PersistentActor {
 
   val receiveCommand: Receive = {
     case Cmd(data) =>
-      persist(Evt(s"${data}-${numEvents}"))(updateState)
-      persist(Evt(s"${data}-${numEvents + 1}")) { event =>
+      persist(Evt(s"${data}-${numEvents}")) { event =>
         updateState(event)
         context.system.eventStream.publish(event)
       }


### PR DESCRIPTION
Updated Scala and Java PersistenceActorExample examples to persist a single event for the single supported command. This makes the code simpler to understand and matches the documentation. 

Resolves #67.