### PR TITLE
update dependencies of akka-sample-persistence-dc

### DIFF
--- a/akka-sample-persistence-dc-java/build.sbt
+++ b/akka-sample-persistence-dc-java/build.sbt
@@ -21,6 +21,8 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-persistence-multi-dc-testkit" % AkkaAddOnsVersion,
   "com.lightbend.akka" %% "akka-split-brain-resolver" % AkkaAddOnsVersion,
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaAddOnsVersion,
+  "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,

--- a/akka-sample-persistence-dc-scala/build.sbt
+++ b/akka-sample-persistence-dc-scala/build.sbt
@@ -21,6 +21,8 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-persistence-multi-dc-testkit" % AkkaAddOnsVersion,
   "com.lightbend.akka" %% "akka-split-brain-resolver" % AkkaAddOnsVersion,
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaAddOnsVersion,
+  "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,


### PR DESCRIPTION
fixing version warning:
```
11:50:19.788 WARN  [akka.util.ManifestInfo] [run-main-0] - Detected possible incompatible versions 
on the classpath. Please note that a given Akka version MUST be the same across all modules of 
Akka that you are using, e.g. if you use [2.5.17] all other modules that are released together MUST 
be of the same version. Make sure you're using a compatible set of libraries.Possibly conflicting 
versions [2.5.15, 2.5.13, 2.5.17] in libraries [akka-persistence:2.5.15, akka-cluster-sharding:2.5.15, 
akka-protobuf:2.5.15, akka-persistence-query:2.5.13, akka-actor:2.5.17, akka-slf4j:2.5.17, 
akka-remote:2.5.15, akka-cluster:2.5.15, akka-distributed-data:2.5.15, akka-stream:2.5.15, 
akka-cluster-tools:2.5.15]
```