### PR TITLE
Fix license: don't refer to Activator, and typo

### DIFF
--- a/akka-sample-camel-java/LICENSE
+++ b/akka-sample-camel-java/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-camel-java/LICENSE
+++ b/akka-sample-camel-java/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-camel-scala/LICENSE
+++ b/akka-sample-camel-scala/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-camel-scala/LICENSE
+++ b/akka-sample-camel-scala/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-cluster-java/LICENSE
+++ b/akka-sample-cluster-java/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-cluster-java/LICENSE
+++ b/akka-sample-cluster-java/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-cluster-scala/LICENSE
+++ b/akka-sample-cluster-scala/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-cluster-scala/LICENSE
+++ b/akka-sample-cluster-scala/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-cqrs-scala/LICENSE
+++ b/akka-sample-cqrs-scala/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-cqrs-scala/LICENSE
+++ b/akka-sample-cqrs-scala/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-distributed-data-java/LICENSE
+++ b/akka-sample-distributed-data-java/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-distributed-data-java/LICENSE
+++ b/akka-sample-distributed-data-java/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-distributed-data-scala/LICENSE
+++ b/akka-sample-distributed-data-scala/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-distributed-data-scala/LICENSE
+++ b/akka-sample-distributed-data-scala/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-fsm-java/LICENSE
+++ b/akka-sample-fsm-java/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-fsm-java/LICENSE
+++ b/akka-sample-fsm-java/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-fsm-scala/LICENSE
+++ b/akka-sample-fsm-scala/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-fsm-scala/LICENSE
+++ b/akka-sample-fsm-scala/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-main-java/LICENSE
+++ b/akka-sample-main-java/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-main-java/LICENSE
+++ b/akka-sample-main-java/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-main-scala/LICENSE
+++ b/akka-sample-main-scala/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-main-scala/LICENSE
+++ b/akka-sample-main-scala/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-multi-node-scala/LICENSE
+++ b/akka-sample-multi-node-scala/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-multi-node-scala/LICENSE
+++ b/akka-sample-multi-node-scala/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-persistence-java/LICENSE
+++ b/akka-sample-persistence-java/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-persistence-java/LICENSE
+++ b/akka-sample-persistence-java/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-persistence-scala/LICENSE
+++ b/akka-sample-persistence-scala/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-persistence-scala/LICENSE
+++ b/akka-sample-persistence-scala/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-sharding-java/LICENSE
+++ b/akka-sample-sharding-java/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-sharding-java/LICENSE
+++ b/akka-sample-sharding-java/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-sharding-scala/LICENSE
+++ b/akka-sample-sharding-scala/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-sharding-scala/LICENSE
+++ b/akka-sample-sharding-scala/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-supervision-java/LICENSE
+++ b/akka-sample-supervision-java/LICENSE
@@ -1,10 +1,10 @@
-Activator Template by Lightbend
+Template by Lightbend
 
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.

--- a/akka-sample-supervision-java/LICENSE
+++ b/akka-sample-supervision-java/LICENSE
@@ -3,7 +3,7 @@ Activator Template by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-vavr/LICENSE
+++ b/akka-sample-vavr/LICENSE
@@ -3,7 +3,7 @@ Akka sample by Lightbend
 Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
-this Activator Tempate has waived all copyright and related or neighboring
+this Template has waived all copyright and related or neighboring
 rights to this Activator Template.
 
 You should have received a copy of the CC0 legalcode along with this

--- a/akka-sample-vavr/LICENSE
+++ b/akka-sample-vavr/LICENSE
@@ -4,7 +4,7 @@ Licensed under Public Domain (CC0)
 
 To the extent possible under law, the person who associated CC0 with
 this Template has waived all copyright and related or neighboring
-rights to this Activator Template.
+rights to this Template.
 
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.


### PR DESCRIPTION
There are two kinds of LICENSE. First refers to `Activator Template` and second `Activator Tempate` (sic).