### PR TITLE
Change artery config back to netty

### DIFF
--- a/akka-sample-cluster-java/src/main/java/sample/cluster/factorial/FactorialBackendMain.java
+++ b/akka-sample-cluster-java/src/main/java/sample/cluster/factorial/FactorialBackendMain.java
@@ -9,10 +9,12 @@ public class FactorialBackendMain {
 
   public static void main(String[] args) {
     // Override the configuration of the port when specified as program argument
+    // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+    // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
     final String port = args.length > 0 ? args[0] : "0";
     final Config config = 
       ConfigFactory.parseString(
-          "akka.remote.artery.canonical.port=" + port).
+          "akka.remote.netty.tcp.port=" + port).
       withFallback(ConfigFactory.parseString("akka.cluster.roles = [backend]")).
       withFallback(ConfigFactory.load("factorial"));
 

--- a/akka-sample-cluster-java/src/main/java/sample/cluster/simple/SimpleClusterApp.java
+++ b/akka-sample-cluster-java/src/main/java/sample/cluster/simple/SimpleClusterApp.java
@@ -18,8 +18,10 @@ public class SimpleClusterApp {
   public static void startup(String[] ports) {
     for (String port : ports) {
       // Override the configuration of the port
+      // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+      // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
       Config config = ConfigFactory.parseString(
-          "akka.remote.artery.canonical.port=" + port)
+          "akka.remote.netty.tcp.port=" + port)
           .withFallback(ConfigFactory.load());
 
       // Create an Akka system

--- a/akka-sample-cluster-java/src/main/java/sample/cluster/stats/StatsSampleMain.java
+++ b/akka-sample-cluster-java/src/main/java/sample/cluster/stats/StatsSampleMain.java
@@ -20,9 +20,11 @@ public class StatsSampleMain {
   public static void startup(String[] ports) {
     for (String port : ports) {
       // Override the configuration of the port
+      // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+      // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
       Config config = 
         ConfigFactory.parseString(
-          "akka.remote.artery.canonical.port=" + port)
+          "akka.remote.netty.tcp.port=" + port)
           .withFallback(
               ConfigFactory.parseString("akka.cluster.roles = [compute]"))
           .withFallback(ConfigFactory.load("stats1"));

--- a/akka-sample-cluster-java/src/main/java/sample/cluster/stats/StatsSampleOneMasterMain.java
+++ b/akka-sample-cluster-java/src/main/java/sample/cluster/stats/StatsSampleOneMasterMain.java
@@ -25,8 +25,10 @@ public class StatsSampleOneMasterMain {
   public static void startup(String[] ports) {
     for (String port : ports) {
       // Override the configuration of the port
+      // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+      // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
       Config config = ConfigFactory.parseString(
-          "akka.remote.artery.canonical.port=" + port)
+          "akka.remote.netty.tcp.port=" + port)
           .withFallback(
               ConfigFactory.parseString("akka.cluster.roles = [compute]"))
           .withFallback(ConfigFactory.load("stats2"));

--- a/akka-sample-cluster-java/src/main/java/sample/cluster/transformation/TransformationBackendMain.java
+++ b/akka-sample-cluster-java/src/main/java/sample/cluster/transformation/TransformationBackendMain.java
@@ -10,10 +10,12 @@ public class TransformationBackendMain {
 
   public static void main(String[] args) {
     // Override the configuration of the port when specified as program argument
+    // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+    // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
     final String port = args.length > 0 ? args[0] : "0";
     final Config config = 
       ConfigFactory.parseString(
-          "akka.remote.artery.canonical.port=" + port)
+          "akka.remote.netty.tcp.port=" + port)
       .withFallback(ConfigFactory.parseString("akka.cluster.roles = [backend]"))
       .withFallback(ConfigFactory.load());
 

--- a/akka-sample-cluster-java/src/main/java/sample/cluster/transformation/TransformationFrontendMain.java
+++ b/akka-sample-cluster-java/src/main/java/sample/cluster/transformation/TransformationFrontendMain.java
@@ -21,10 +21,12 @@ public class TransformationFrontendMain {
 
   public static void main(String[] args) {
     // Override the configuration of the port when specified as program argument
+    // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+    // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
     final String port = args.length > 0 ? args[0] : "0";
     final Config config = 
       ConfigFactory.parseString(
-          "akka.remote.artery.canonical.port=" + port)
+          "akka.remote.netty.tcp.port=" + port)
       .withFallback(ConfigFactory.parseString("akka.cluster.roles = [frontend]"))
       .withFallback(ConfigFactory.load());
 

--- a/akka-sample-cluster-java/src/main/resources/application.conf
+++ b/akka-sample-cluster-java/src/main/resources/application.conf
@@ -3,8 +3,15 @@ akka {
     provider = "cluster"
   }
   remote {
+    netty.tcp {
+      hostname = "127.0.0.1"
+      port = 0
+    }
+
     artery {
-      enabled = on
+      # change this to enabled=on to use Artery instead of netty
+      # see https://doc.akka.io/docs/akka/current/remoting-artery.html
+      enabled = off
       transport = tcp
       canonical.hostname = "127.0.0.1"
       canonical.port = 0
@@ -12,9 +19,10 @@ akka {
   }
 
   cluster {
+    # Note - Artery uses akka:// addresses
     seed-nodes = [
-      "akka://ClusterSystem@127.0.0.1:2551",
-      "akka://ClusterSystem@127.0.0.1:2552"]
+      "akka.tcp://ClusterSystem@127.0.0.1:2551",
+      "akka.tcp://ClusterSystem@127.0.0.1:2552"]
 
     # auto downing is NOT safe for production deployments.
     # you may want to use it during development, read more about it in the docs.

--- a/akka-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -48,8 +48,7 @@ object StatsSampleSingleMasterSpecConfig extends MultiNodeConfig {
   commonConfig(ConfigFactory.parseString("""
     akka.loglevel = INFO
     akka.actor.provider = cluster
-    akka.remote.artery.enabled = on
-    akka.remote.artery.transport = tcp
+    akka.remote.enabled-transports = [akka.remote.netty.tcp]
     akka.cluster.roles = [compute]
     #//#router-deploy-config
     akka.actor.deployment {

--- a/akka-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/akka-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -43,8 +43,7 @@ object StatsSampleSpecConfig extends MultiNodeConfig {
   // note that no fixed host names and ports are used
   commonConfig(ConfigFactory.parseString("""
     akka.actor.provider = cluster
-    akka.remote.artery.enabled = on
-    akka.remote.artery.transport = tcp
+    akka.remote.enabled-transports = [akka.remote.netty.tcp]
     akka.cluster.roles = [compute]
     #//#router-lookup-config  
     akka.actor.deployment {

--- a/akka-sample-cluster-java/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
+++ b/akka-sample-cluster-java/src/multi-jvm/scala/sample/cluster/transformation/TransformationSampleSpec.scala
@@ -42,8 +42,7 @@ object TransformationSampleSpecConfig extends MultiNodeConfig {
   // note that no fixed host names and ports are used
   commonConfig(ConfigFactory.parseString("""
     akka.actor.provider = cluster
-    akka.remote.artery.enabled = on
-    akka.remote.artery.transport = tcp
+    akka.remote.enabled-transports = [akka.remote.netty.tcp]
     """))
 
   nodeConfig(frontend1, frontend2)(

--- a/akka-sample-cluster-scala/src/main/resources/application.conf
+++ b/akka-sample-cluster-scala/src/main/resources/application.conf
@@ -3,7 +3,14 @@ akka {
     provider = cluster
   }
   remote {
+    netty.tcp {
+      hostname = "127.0.0.1"
+      port = 0
+    }
+
     artery {
+      # change this to enabled=on to use Artery instead of netty
+      # see https://doc.akka.io/docs/akka/current/remoting-artery.html
       enabled = on
       transport = tcp
       canonical.hostname = "127.0.0.1"
@@ -13,8 +20,8 @@ akka {
 
   cluster {
     seed-nodes = [
-      "akka://ClusterSystem@127.0.0.1:2551",
-      "akka://ClusterSystem@127.0.0.1:2552"]
+      "akka.tcp://ClusterSystem@127.0.0.1:2551",
+      "akka.tcp://ClusterSystem@127.0.0.1:2552"]
 
     # auto downing is NOT safe for production deployments.
     # you may want to use it during development, read more about it in the docs.

--- a/akka-sample-cluster-scala/src/main/scala/sample/cluster/factorial/FactorialBackend.scala
+++ b/akka-sample-cluster-scala/src/main/scala/sample/cluster/factorial/FactorialBackend.scala
@@ -31,9 +31,11 @@ class FactorialBackend extends Actor with ActorLogging {
 object FactorialBackend {
   def main(args: Array[String]): Unit = {
     // Override the configuration of the port when specified as program argument
+    // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+    // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
     val port = if (args.isEmpty) "0" else args(0)
     val config = ConfigFactory.parseString(s"""
-        akka.remote.artery.canonical.port=$port
+        akka.remote.netty.tcp.port=$port
         """)
       .withFallback(ConfigFactory.parseString("akka.cluster.roles = [backend]"))
       .withFallback(ConfigFactory.load("factorial"))

--- a/akka-sample-cluster-scala/src/main/scala/sample/cluster/simple/SimpleClusterApp.scala
+++ b/akka-sample-cluster-scala/src/main/scala/sample/cluster/simple/SimpleClusterApp.scala
@@ -15,8 +15,10 @@ object SimpleClusterApp {
   def startup(ports: Seq[String]): Unit = {
     ports foreach { port =>
       // Override the configuration of the port
+      // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+      // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
       val config = ConfigFactory.parseString(s"""
-        akka.remote.artery.canonical.port=$port
+        akka.remote.netty.tcp.port=$port
         """).withFallback(ConfigFactory.load())
 
       // Create an Akka system

--- a/akka-sample-cluster-scala/src/main/scala/sample/cluster/stats/StatsSample.scala
+++ b/akka-sample-cluster-scala/src/main/scala/sample/cluster/stats/StatsSample.scala
@@ -27,8 +27,10 @@ object StatsSample {
   def startup(ports: Seq[String]): Unit = {
     ports foreach { port =>
       // Override the configuration of the port when specified as program argument
+      // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+      // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
       val config = ConfigFactory.parseString(s"""
-        akka.remote.artery.canonical.port=$port
+        akka.remote.netty.tcp.port=$port
         """)
         .withFallback(
           ConfigFactory.parseString("akka.cluster.roles = [compute]")).

--- a/akka-sample-cluster-scala/src/main/scala/sample/cluster/stats/StatsSampleOneMaster.scala
+++ b/akka-sample-cluster-scala/src/main/scala/sample/cluster/stats/StatsSampleOneMaster.scala
@@ -22,9 +22,11 @@ object StatsSampleOneMaster {
   def startup(ports: Seq[String]): Unit = {
     ports foreach { port =>
       // Override the configuration of the port when specified as program argument
+      // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+      // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
       val config =
         ConfigFactory.parseString(s"""
-          akka.remote.artery.canonical.port=$port
+          akka.remote.netty.tcp.port=$port
           """).withFallback(
           ConfigFactory.parseString("akka.cluster.roles = [compute]")).
           withFallback(ConfigFactory.load("stats2"))

--- a/akka-sample-cluster-scala/src/main/scala/sample/cluster/transformation/TransformationBackend.scala
+++ b/akka-sample-cluster-scala/src/main/scala/sample/cluster/transformation/TransformationBackend.scala
@@ -41,9 +41,11 @@ class TransformationBackend extends Actor {
 object TransformationBackend {
   def main(args: Array[String]): Unit = {
     // Override the configuration of the port when specified as program argument
+    // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+    // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
     val port = if (args.isEmpty) "0" else args(0)
     val config = ConfigFactory.parseString(s"""
-        akka.remote.artery.canonical.port=$port
+        akka.remote.netty.tcp.port=$port
         """)
       .withFallback(ConfigFactory.parseString("akka.cluster.roles = [backend]"))
       .withFallback(ConfigFactory.load())

--- a/akka-sample-cluster-scala/src/main/scala/sample/cluster/transformation/TransformationFrontend.scala
+++ b/akka-sample-cluster-scala/src/main/scala/sample/cluster/transformation/TransformationFrontend.scala
@@ -39,9 +39,11 @@ class TransformationFrontend extends Actor {
 object TransformationFrontend {
   def main(args: Array[String]): Unit = {
     // Override the configuration of the port when specified as program argument
+    // To use artery instead of netty, change to "akka.remote.artery.canonical.port"
+    // See https://doc.akka.io/docs/akka/current/remoting-artery.html for details
     val port = if (args.isEmpty) "0" else args(0)
     val config = ConfigFactory.parseString(s"""
-        akka.remote.artery.canonical.port=$port
+        akka.remote.netty.tcp.port=$port
         """)
       .withFallback(ConfigFactory.parseString("akka.cluster.roles = [frontend]"))
       .withFallback(ConfigFactory.load())

--- a/akka-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -47,8 +47,10 @@ object StatsSampleSingleMasterSpecConfig extends MultiNodeConfig {
   commonConfig(ConfigFactory.parseString("""
     akka.loglevel = INFO
     akka.actor.provider = cluster
-    akka.remote.artery.enabled = on
-    akka.remote.artery.transport = tcp
+    akka.remote.enabled-transports = [akka.remote.netty.tcp]
+    # To use artery, disable netty line above, and uncomment lines below
+    ##akka.remote.artery.enabled = on
+    ##akka.remote.artery.transport = tcp
     akka.cluster.roles = [compute]
     #//#router-deploy-config
     akka.actor.deployment {

--- a/akka-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/akka-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -38,8 +38,10 @@ object StatsSampleSpecConfig extends MultiNodeConfig {
   // note that no fixed host names and ports are used
   commonConfig(ConfigFactory.parseString("""
     akka.actor.provider = cluster
-    akka.remote.artery.enabled = on
-    akka.remote.artery.transport = tcp
+    akka.remote.enabled-transports = [akka.remote.netty.tcp]
+    # To use artery, disable netty line above, and uncomment lines below
+    ##akka.remote.artery.enabled = on
+    ##akka.remote.artery.transport = tcp
     akka.cluster.roles = [compute]
     #//#router-lookup-config
     akka.actor.deployment {


### PR DESCRIPTION
See [akka issue #26232](https://github.com/akka/akka/issues/26232) for more details.

A user looking at the docs page would see netty configurations.  However, if they wanted to take the next step and see a full working example, they would only see artery configurations.  If they copied code/config from both places, they might end up in a confusing situation where they have netty AND artery code/config mixed, and a non-working cluster application.

I changed things back for java and scala cluster samples, and added comments in key locations for anyone wishing to explore artery.