### PR TITLE
Remove akka-sample-remote-java/scala documentation

### DIFF
--- a/docs-gen/akka-sample-remote-java/build.sbt
+++ b/docs-gen/akka-sample-remote-java/build.sbt
@@ -1,2 +1,0 @@
-// This gets replaced later automatically
-paradoxTheme := Some(builtinParadoxTheme("generic"))

--- a/docs-gen/akka-sample-remote-scala/build.sbt
+++ b/docs-gen/akka-sample-remote-scala/build.sbt
@@ -1,2 +1,0 @@
-// This gets replaced later automatically
-paradoxTheme := Some(builtinParadoxTheme("generic"))

--- a/docs-gen/build.sbt
+++ b/docs-gen/build.sbt
@@ -82,20 +82,6 @@ lazy val `akka-sample-persistence-scala` = project
     baseProject := "akka-sample-persistence-scala"
   )
 
-lazy val `akka-sample-remote-java` = project
-  .enablePlugins(AkkaSamplePlugin)
-  .settings(
-    name        := "Akka Remote with Java",
-    baseProject := "akka-sample-remote-java"
-  )
-
-lazy val `akka-sample-remote-scala` = project
-  .enablePlugins(AkkaSamplePlugin)
-  .settings(
-    name        := "Akka Remote with Scala",
-    baseProject := "akka-sample-remote-scala"
-  )
-
 lazy val `akka-sample-supervision-java` = project
   .enablePlugins(AkkaSamplePlugin)
   .settings(


### PR DESCRIPTION
These samples were removed in #72.

## Purpose

Removes outdated documentation projects. These were causing errors in the Tech Hub site build.

## References

References #72, #77