### PR TITLE
Fix for runtime logback configuration parsing exception

### DIFF
--- a/akka-sample-fsm-scala/src/main/resources/logback.xml
+++ b/akka-sample-fsm-scala/src/main/resources/logback.xml
@@ -15,4 +15,4 @@
         <appender-ref ref="ASYNC"/>
     </root>
 
-</configuration
+</configuration>


### PR DESCRIPTION
Resolves #177 

Added missing closing > in root configuration element of logback.xml

Example runtime error:

  12:14:53,585 |-ERROR in
  ch.qos.logback.core.joran.event.SaxEventRecorder@584740ac - XML_PARSING
  - Parsing fatal error on line 19 and column 1
  12:14:53,585 |-ERROR in
  ch.qos.logback.core.joran.event.SaxEventRecorder@584740ac -
  org.xml.sax.SAXParseException; systemId:
  jar:file:...elided.../akka-sample-fsm-scala_2.13-HEAD+20191230-1214.jar!/logback.xml;
  lineNumber: 19; columnNumber: 1; XML document structures must start and
  end within the same entity.

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
