### PR TITLE
Update cluster client replacement examples to Akka gRPC 0.8.4

### DIFF
--- a/akka-sample-cluster-client-grpc-java/build.sbt
+++ b/akka-sample-cluster-client-grpc-java/build.sbt
@@ -6,7 +6,7 @@ lazy val `akka-sample-cluster-client-grpc-java` = project
   .enablePlugins(AkkaGrpcPlugin)
   .settings(
     organization := "com.typesafe.akka",
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.13.2",
     javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation", "-parameters"),
     akkaGrpcGeneratedLanguages := Seq(AkkaGrpc.Java),
     // javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.9" % "runtime",

--- a/akka-sample-cluster-client-grpc-java/pom.xml
+++ b/akka-sample-cluster-client-grpc-java/pom.xml
@@ -7,7 +7,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <akka.version>2.6.5</akka.version>
-    <akka.grpc.version>0.7.2</akka.grpc.version>
+    <akka.grpc.version>0.8.4</akka.grpc.version>
   </properties>
 
   <groupId>com.lightbend.akka.samples</groupId>
@@ -18,37 +18,37 @@
   <dependencies>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-stream_2.12</artifactId>
+      <artifactId>akka-stream_2.13</artifactId>
       <version>${akka.version}</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-cluster_2.12</artifactId>
+      <artifactId>akka-cluster_2.13</artifactId>
       <version>${akka.version}</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-cluster-tools_2.12</artifactId>
+      <artifactId>akka-cluster-tools_2.13</artifactId>
       <version>${akka.version}</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-serialization-jackson_2.12</artifactId>
+      <artifactId>akka-serialization-jackson_2.13</artifactId>
       <version>${akka.version}</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-discovery_2.12</artifactId>
+      <artifactId>akka-discovery_2.13</artifactId>
       <version>${akka.version}</version>
     </dependency>
     <dependency>
       <groupId>com.lightbend.akka.grpc</groupId>
-      <artifactId>akka-grpc-runtime_2.12</artifactId>
+      <artifactId>akka-grpc-runtime_2.13</artifactId>
       <version>${akka.grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-testkit_2.12</artifactId>
+      <artifactId>akka-testkit_2.13</artifactId>
       <version>${akka.version}</version>
       <scope>test</scope>
     </dependency>

--- a/akka-sample-cluster-client-grpc-java/project/build.properties
+++ b/akka-sample-cluster-client-grpc-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.10

--- a/akka-sample-cluster-client-grpc-java/project/build.properties
+++ b/akka-sample-cluster-client-grpc-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.9

--- a/akka-sample-cluster-client-grpc-java/project/plugins.sbt
+++ b/akka-sample-cluster-client-grpc-java/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.7.2")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.8.4")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")

--- a/akka-sample-cluster-client-grpc-java/src/main/java/sample/cluster/client/grpc/ClusterClient.java
+++ b/akka-sample-cluster-client-grpc-java/src/main/java/sample/cluster/client/grpc/ClusterClient.java
@@ -17,6 +17,7 @@ import akka.stream.javadsl.Source;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -150,7 +151,14 @@ public class ClusterClient extends AbstractLoggingActor {
     receptionistServiceClient
       .newSession(
         Source
-          .actorRef(settings.bufferSize, OverflowStrategy.dropNew())
+          .actorRef(
+            // never complete from stream element
+            elem -> Optional.empty(),
+            // never fail from stream element
+            elem -> Optional.empty(),
+            settings.bufferSize,
+            OverflowStrategy.dropNew()
+            )
           .via(killSwitch.flow())
           .map(msg -> {
             if (msg instanceof Send) {

--- a/akka-sample-cluster-client-grpc-java/src/main/java/sample/cluster/client/grpc/ClusterClientReceptionist.java
+++ b/akka-sample-cluster-client-grpc-java/src/main/java/sample/cluster/client/grpc/ClusterClientReceptionist.java
@@ -13,8 +13,8 @@ import akka.event.Logging;
 import akka.event.LoggingAdapter;
 import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
-import akka.http.javadsl.UseHttp2;
 import akka.stream.Materializer;
+import akka.stream.SystemMaterializer;
 
 import java.util.Optional;
 
@@ -60,12 +60,12 @@ final class ClusterClientReceptionist implements Extension {
 
     ClusterClientSerialization serialization = new ClusterClientSerialization(system);
 
-    Materializer materializer = Materializer.createMaterializer(system);
+    Materializer materializer = SystemMaterializer.get(system).materializer();
 
     Http.get(system).bindAndHandleAsync(
       ClusterClientReceptionistServiceHandlerFactory.create(
         new ClusterClientReceptionistGrpcImpl(settings, pubSubMediator(), serialization, materializer, log),
-        materializer, system),
+        system),
       ConnectHttp.toHost(settings.hostPort.hostname, settings.hostPort.port),
       materializer)
       .whenComplete((result, exc) -> {

--- a/akka-sample-cluster-client-grpc-scala/build.sbt
+++ b/akka-sample-cluster-client-grpc-scala/build.sbt
@@ -10,7 +10,7 @@ lazy val `akka-sample-cluster-client-grpc-scala` = project
   .settings(multiJvmSettings: _*)
   .settings(
     organization := "com.typesafe.akka",
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.13.2",
     scalacOptions in Compile ++= Seq(
       "-deprecation",
       "-feature",
@@ -26,7 +26,7 @@ lazy val `akka-sample-cluster-client-grpc-scala` = project
       "com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion,
       "com.typesafe.akka" %% "akka-discovery" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % Test,
-      "org.scalatest" %% "scalatest" % "3.0.1" % Test
+      "org.scalatest" %% "scalatest" % "3.1.1" % Test
     )
   )
   .configs(MultiJvm)

--- a/akka-sample-cluster-client-grpc-scala/project/build.properties
+++ b/akka-sample-cluster-client-grpc-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.10

--- a/akka-sample-cluster-client-grpc-scala/project/build.properties
+++ b/akka-sample-cluster-client-grpc-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.9

--- a/akka-sample-cluster-client-grpc-scala/project/plugins.sbt
+++ b/akka-sample-cluster-client-grpc-scala/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.7.2")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "0.8.4")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")

--- a/akka-sample-cluster-client-grpc-scala/src/main/scala/sample/cluster/client/grpc/ClusterClient.scala
+++ b/akka-sample-cluster-client-grpc-scala/src/main/scala/sample/cluster/client/grpc/ClusterClient.scala
@@ -1,52 +1,52 @@
 package sample.cluster.client.grpc
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.concurrent.duration._
-
 import akka.NotUsed
-import akka.actor.Actor
-import akka.actor.ActorLogging
-import akka.actor.ActorRef
-import akka.actor.ActorSystem
-import akka.actor.Props
-import akka.actor.Terminated
+import akka.actor.{
+  Actor,
+  ActorLogging,
+  ActorRef,
+  ActorSystem,
+  Props,
+  Terminated
+}
 import akka.event.LoggingAdapter
 import akka.grpc.GrpcClientSettings
-import akka.stream.Materializer
-import akka.stream.KillSwitches
-import akka.stream.OverflowStrategy
-import akka.stream.SharedKillSwitch
-import akka.stream.WatchedActorTerminatedException
 import akka.stream.scaladsl.Source
+import akka.stream._
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
 
 object ClusterClient {
 
   /**
-   * Factory method for `ClusterClient` [[akka.actor.Props]].
-   */
-  def props(settings: ClusterClientSettings)(implicit materializer: Materializer): Props =
+    * Factory method for `ClusterClient` [[akka.actor.Props]].
+    */
+  def props(
+    settings: ClusterClientSettings
+  )(implicit materializer: Materializer): Props =
     Props(new ClusterClient(settings))
 
   sealed trait Command
 
-  final case class Send(path: String, msg: Any, localAffinity: Boolean) extends Command {
+  final case class Send(path: String, msg: Any, localAffinity: Boolean)
+      extends Command {
 
     /**
-     * Convenience constructor with `localAffinity` false
-     */
+      * Convenience constructor with `localAffinity` false
+      */
     def this(path: String, msg: Any) = this(path, msg, localAffinity = false)
   }
 
   /**
-   * More efficient than `Send` for single request-reply interaction
-   */
-  final case class SendAsk(path: String, msg: Any, localAffinity: Boolean) extends Command {
+    * More efficient than `Send` for single request-reply interaction
+    */
+  final case class SendAsk(path: String, msg: Any, localAffinity: Boolean)
+      extends Command {
 
     /**
-     * Convenience constructor with `localAffinity` false
-     */
+      * Convenience constructor with `localAffinity` false
+      */
     def this(path: String, msg: Any) = this(path, msg, localAffinity = false)
   }
 
@@ -54,30 +54,42 @@ object ClusterClient {
 
   final case class Publish(topic: String, msg: Any) extends Command
 
-  private def createClientStub(settings: ClusterClientSettings)(
-      implicit mat: Materializer): ClusterClientReceptionistServiceClient = {
+  private def createClientStub(
+    settings: ClusterClientSettings
+  )(implicit mat: Materializer): ClusterClientReceptionistServiceClient = {
     implicit val ec: ExecutionContext = mat.executionContext
     ClusterClientReceptionistServiceClient(settings.grpcClientSettings)
   }
 
   private def newSession(
-      settings: ClusterClientSettings,
-      receptionistServiceClient: ClusterClientReceptionistServiceClient,
-      sender: ActorRef,
-      killSwitch: SharedKillSwitch,
-      log: LoggingAdapter,
-      serialization: ClusterClientSerialization)(implicit mat: Materializer): Future[ActorRef] = {
+    settings: ClusterClientSettings,
+    receptionistServiceClient: ClusterClientReceptionistServiceClient,
+    sender: ActorRef,
+    killSwitch: SharedKillSwitch,
+    log: LoggingAdapter,
+    serialization: ClusterClientSerialization
+  )(implicit mat: Materializer): Future[ActorRef] = {
     val sessionReqRefPromise = Promise[ActorRef]()
     log.info("New session for {}", sender)
     receptionistServiceClient
       .newSession(
         Source
-          .actorRef[Any](bufferSize = settings.bufferSize, overflowStrategy = OverflowStrategy.dropNew)
+          .actorRef[Any](
+            bufferSize = settings.bufferSize,
+            overflowStrategy = OverflowStrategy.dropNew,
+            // never complete from stream element
+            completionMatcher = PartialFunction.empty,
+            // never fail from stream element
+            failureMatcher = PartialFunction.empty
+          )
+          // .actorRef[Any](bufferSize = settings.bufferSize, overflowStrategy = OverflowStrategy.dropNew)
           .via(killSwitch.flow)
           .map {
             case send: Send =>
               val payload = serialization.serializePayload(send.msg)
-              Req().withSend(SendReq(send.path, send.localAffinity, Some(payload)))
+              Req().withSend(
+                SendReq(send.path, send.localAffinity, Some(payload))
+              )
             case sendToAll: SendToAll =>
               val payload = serialization.serializePayload(sendToAll.msg)
               Req().withSendToAll(SendToAllReq(sendToAll.path, Some(payload)))
@@ -88,9 +100,12 @@ object ClusterClient {
           .mapMaterializedValue(sessionReqRef => {
             sessionReqRefPromise.success(sessionReqRef)
             NotUsed
-          }))
+          })
+      )
       .watch(sender) // end session when original sender terminates
-      .recoverWithRetries(-1, { case _: WatchedActorTerminatedException => Source.empty })
+      .recoverWithRetries(-1, {
+        case _: WatchedActorTerminatedException => Source.empty
+      })
       .map { rsp =>
         serialization.deserializePayload(rsp.payload.get)
       }
@@ -103,9 +118,10 @@ object ClusterClient {
   }
 
   private def askSend(
-      receptionistServiceClient: ClusterClientReceptionistServiceClient,
-      send: SendAsk,
-      serialization: ClusterClientSerialization)(implicit ec: ExecutionContext): Future[Any] = {
+    receptionistServiceClient: ClusterClientReceptionistServiceClient,
+    send: SendAsk,
+    serialization: ClusterClientSerialization
+  )(implicit ec: ExecutionContext): Future[Any] = {
     val payload = serialization.serializePayload(send.msg)
     val sendReq = SendReq(send.path, send.localAffinity, Some(payload))
     receptionistServiceClient.askSend(sendReq).map { rsp =>
@@ -115,52 +131,54 @@ object ClusterClient {
 }
 
 /**
- * This actor is intended to be used on an external node that is not member
- * of the cluster. It acts like a gateway for sending messages to actors
- * somewhere in the cluster. With service discovery and Akka gRPC it will establish
- * a connection to a [[ClusterClientReceptionist]] somewhere in the cluster.
- *
- * You can send messages via the `ClusterClient` to any actor in the cluster
- * that is registered in the [[ClusterClientReceptionist]].
- * Messages are wrapped in [[ClusterClient#Send]], [[ClusterClient#SendToAll]]
- * or [[ClusterClient#Publish]].
- *
- * 1. [[ClusterClient#Send]] -
- * The message will be delivered to one recipient with a matching path, if any such
- * exists. If several entries match the path the message will be delivered
- * to one random destination. The sender of the message can specify that local
- * affinity is preferred, i.e. the message is sent to an actor in the same local actor
- * system as the used receptionist actor, if any such exists, otherwise random to any other
- * matching entry.
- *
- * 2. [[ClusterClient#SendToAll]] -
- * The message will be delivered to all recipients with a matching path.
- *
- * 3. [[ClusterClient#Publish]] -
- * The message will be delivered to all recipients Actors that have been registered as subscribers to
- * to the named topic.
- *
- * Use the factory method [[ClusterClient#props]]) to create the
- * [[akka.actor.Props]] for the actor.
- *
- * If the receptionist is not currently available, the client will buffer the messages
- * and then deliver them when the connection to the receptionist has been established.
- * The size of the buffer is configurable and it can be disabled by using a buffer size
- * of 0. When the buffer is full old messages will be dropped when new messages are sent
- * via the client.
- *
- * Note that this is a best effort implementation: messages can always be lost due to the distributed
- * nature of the actors involved.
- */
-final class ClusterClient(settings: ClusterClientSettings)(implicit materializer: Materializer)
-    extends Actor
+  * This actor is intended to be used on an external node that is not member
+  * of the cluster. It acts like a gateway for sending messages to actors
+  * somewhere in the cluster. With service discovery and Akka gRPC it will establish
+  * a connection to a [[ClusterClientReceptionist]] somewhere in the cluster.
+  *
+  * You can send messages via the `ClusterClient` to any actor in the cluster
+  * that is registered in the [[ClusterClientReceptionist]].
+  * Messages are wrapped in [[ClusterClient#Send]], [[ClusterClient#SendToAll]]
+  * or [[ClusterClient#Publish]].
+  *
+  * 1. [[ClusterClient#Send]] -
+  * The message will be delivered to one recipient with a matching path, if any such
+  * exists. If several entries match the path the message will be delivered
+  * to one random destination. The sender of the message can specify that local
+  * affinity is preferred, i.e. the message is sent to an actor in the same local actor
+  * system as the used receptionist actor, if any such exists, otherwise random to any other
+  * matching entry.
+  *
+  * 2. [[ClusterClient#SendToAll]] -
+  * The message will be delivered to all recipients with a matching path.
+  *
+  * 3. [[ClusterClient#Publish]] -
+  * The message will be delivered to all recipients Actors that have been registered as subscribers to
+  * to the named topic.
+  *
+  * Use the factory method [[ClusterClient#props]]) to create the
+  * [[akka.actor.Props]] for the actor.
+  *
+  * If the receptionist is not currently available, the client will buffer the messages
+  * and then deliver them when the connection to the receptionist has been established.
+  * The size of the buffer is configurable and it can be disabled by using a buffer size
+  * of 0. When the buffer is full old messages will be dropped when new messages are sent
+  * via the client.
+  *
+  * Note that this is a best effort implementation: messages can always be lost due to the distributed
+  * nature of the actors involved.
+  */
+final class ClusterClient(settings: ClusterClientSettings)(
+  implicit materializer: Materializer
+) extends Actor
     with ActorLogging {
 
   import ClusterClient._
 
   val serialization = new ClusterClientSerialization(context.system)
 
-  private val receptionistServiceClient: ClusterClientReceptionistServiceClient = createClientStub(settings)
+  private val receptionistServiceClient
+    : ClusterClientReceptionistServiceClient = createClientStub(settings)
 
   // Original sender -> stream Source.actorRef of the session
   private var sessionRef: Map[ActorRef, Future[ActorRef]] = Map.empty
@@ -184,7 +202,14 @@ final class ClusterClient(settings: ClusterClientSettings)(implicit materializer
       val session = sessionRef.get(originalSender) match {
         case Some(ses) => ses
         case None =>
-          val ses = newSession(settings, receptionistServiceClient, originalSender, killSwitch, log, serialization)
+          val ses = newSession(
+            settings,
+            receptionistServiceClient,
+            originalSender,
+            killSwitch,
+            log,
+            serialization
+          )
           sessionRef = sessionRef.updated(originalSender, ses)
           ses
       }
@@ -203,9 +228,9 @@ final class ClusterClient(settings: ClusterClientSettings)(implicit materializer
 object ClusterClientSettings {
 
   /**
-   * Create settings from the default configuration
-   * `sample.cluster.client.grpc`.
-   */
+    * Create settings from the default configuration
+    * `sample.cluster.client.grpc`.
+    */
   def apply(system: ActorSystem): ClusterClientSettings = {
     val config = system.settings.config.getConfig("sample.cluster.client.grpc")
     val grpcClientSettings = GrpcClientSettings
@@ -214,9 +239,13 @@ object ClusterClientSettings {
       .withDeadline(3.second) // FIXME config
       .withTls(false)
 
-    new ClusterClientSettings(bufferSize = config.getInt("buffer-size"), grpcClientSettings)
+    new ClusterClientSettings(
+      bufferSize = config.getInt("buffer-size"),
+      grpcClientSettings
+    )
   }
 
 }
 
-final case class ClusterClientSettings(bufferSize: Int, grpcClientSettings: GrpcClientSettings)
+final case class ClusterClientSettings(bufferSize: Int,
+                                       grpcClientSettings: GrpcClientSettings)

--- a/akka-sample-cluster-client-grpc-scala/src/main/scala/sample/cluster/client/grpc/ClusterClient.scala
+++ b/akka-sample-cluster-client-grpc-scala/src/main/scala/sample/cluster/client/grpc/ClusterClient.scala
@@ -1,21 +1,14 @@
 package sample.cluster.client.grpc
 
 import akka.NotUsed
-import akka.actor.{
-  Actor,
-  ActorLogging,
-  ActorRef,
-  ActorSystem,
-  Props,
-  Terminated
-}
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props, Terminated}
 import akka.event.LoggingAdapter
 import akka.grpc.GrpcClientSettings
-import akka.stream.scaladsl.Source
 import akka.stream._
+import akka.stream.scaladsl.Source
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 object ClusterClient {
 

--- a/akka-sample-cluster-client-grpc-scala/src/main/scala/sample/cluster/client/grpc/ClusterClientReceptionistGrpcImpl.scala
+++ b/akka-sample-cluster-client-grpc-scala/src/main/scala/sample/cluster/client/grpc/ClusterClientReceptionistGrpcImpl.scala
@@ -2,32 +2,38 @@ package sample.cluster.client.grpc
 
 import java.util.UUID
 
-import scala.concurrent.Future
-import scala.util.control.NonFatal
-
 import akka.NotUsed
 import akka.actor.ActorRef
 import akka.cluster.pubsub.DistributedPubSubMediator
 import akka.event.LoggingAdapter
-import akka.stream.Materializer
-import akka.stream.OverflowStrategy
+import akka.stream.{Materializer, OverflowStrategy}
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
 
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
 class ClusterClientReceptionistGrpcImpl(
-    settings: ClusterReceptionistSettings,
-    pubSubMediator: ActorRef,
-    serialization: ClusterClientSerialization)(
-    implicit
-    mat: Materializer,
-    log: LoggingAdapter)
+  settings: ClusterReceptionistSettings,
+  pubSubMediator: ActorRef,
+  serialization: ClusterClientSerialization
+)(implicit
+  mat: Materializer,
+  log: LoggingAdapter)
     extends ClusterClientReceptionistService {
 
   override def newSession(in: Source[Req, NotUsed]): Source[Rsp, NotUsed] = {
     val sessionId = UUID.randomUUID().toString
     log.info("New session [{}]", sessionId)
     Source
-      .actorRef[Any](bufferSize = settings.bufferSize, OverflowStrategy.dropNew)
+      .actorRef[Any](
+        bufferSize = settings.bufferSize,
+        overflowStrategy = OverflowStrategy.dropNew,
+        // never complete from stream element
+        completionMatcher = PartialFunction.empty,
+        // never fail from stream element
+        failureMatcher = PartialFunction.empty
+      )
       .map { rsp =>
         val payload = serialization.serializePayload(rsp)
         Rsp(Some(payload))
@@ -39,16 +45,25 @@ class ClusterClientReceptionistGrpcImpl(
               val msg = serialization.deserializePayload(sendReq.payload.get)
               // using sessionRspRef as sender so that replies are emitted to the response stream back to the client
               pubSubMediator.tell(
-                DistributedPubSubMediator.Send(sendReq.path, msg, sendReq.localAffinity),
-                sessionRspRef)
+                DistributedPubSubMediator
+                  .Send(sendReq.path, msg, sendReq.localAffinity),
+                sessionRspRef
+              )
             } else if (req.req.isSendToAll) {
               val sendToAllReq = req.getSendToAll
-              val msg = serialization.deserializePayload(sendToAllReq.payload.get)
-              pubSubMediator.tell(DistributedPubSubMediator.SendToAll(sendToAllReq.path, msg), sessionRspRef)
+              val msg =
+                serialization.deserializePayload(sendToAllReq.payload.get)
+              pubSubMediator.tell(
+                DistributedPubSubMediator.SendToAll(sendToAllReq.path, msg),
+                sessionRspRef
+              )
             } else if (req.req.isPublish) {
               val publishReq = req.getPublish
               val msg = serialization.deserializePayload(publishReq.payload.get)
-              pubSubMediator.tell(DistributedPubSubMediator.Publish(publishReq.topic, msg), sessionRspRef)
+              pubSubMediator.tell(
+                DistributedPubSubMediator.Publish(publishReq.topic, msg),
+                sessionRspRef
+              )
             } else {
               throw new IllegalArgumentException("Unknown request type")
             }
@@ -67,7 +82,11 @@ class ClusterClientReceptionistGrpcImpl(
       implicit val timeout = Timeout(settings.askSendTimeout)
       implicit val ec = mat.executionContext
       val msg = serialization.deserializePayload(sendReq.payload.get)
-      (pubSubMediator ? DistributedPubSubMediator.Send(sendReq.path, msg, sendReq.localAffinity)).map { rsp =>
+      (pubSubMediator ? DistributedPubSubMediator.Send(
+        sendReq.path,
+        msg,
+        sendReq.localAffinity
+      )).map { rsp =>
         val payload = serialization.serializePayload(rsp)
         Rsp(Some(payload))
       }

--- a/akka-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/akka-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -1,32 +1,20 @@
 package sample.cluster.stats
 
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.typed.scaladsl.AskPattern._
-import akka.actor.typed.scaladsl.adapter._
-import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.Routers
 import akka.actor.typed.ActorRef
-import akka.actor.typed.Behavior
-import akka.actor.typed.Props
-import akka.actor.typed.SpawnProtocol
+import akka.actor.typed.scaladsl.{Behaviors, Routers}
+import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.Cluster
-import akka.cluster.ClusterEvent.CurrentClusterState
-import akka.cluster.ClusterEvent.MemberUp
-import akka.cluster.typed.ClusterSingleton
-import akka.cluster.typed.ClusterSingletonSettings
-import akka.cluster.typed.SingletonActor
-import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
+import akka.cluster.ClusterEvent.{CurrentClusterState, MemberUp}
+import akka.cluster.typed.{ClusterSingleton, ClusterSingletonSettings, SingletonActor}
+import akka.remote.testkit.{MultiNodeConfig, MultiNodeSpec}
 import akka.testkit.ImplicitSender
-import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.Matchers
-import org.scalatest.WordSpecLike
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
-import scala.concurrent.Await
-import scala.concurrent.Future
 
 object StatsSampleSingleMasterSpecConfig extends MultiNodeConfig {
   // register the named roles (nodes) of the test
@@ -46,12 +34,19 @@ object StatsSampleSingleMasterSpecConfig extends MultiNodeConfig {
 }
 
 // need one concrete test class per node
-class StatsSampleSingleMasterSpecMultiJvmNode1 extends StatsSampleSingleMasterSpec
-class StatsSampleSingleMasterSpecMultiJvmNode2 extends StatsSampleSingleMasterSpec
-class StatsSampleSingleMasterSpecMultiJvmNode3 extends StatsSampleSingleMasterSpec
+class StatsSampleSingleMasterSpecMultiJvmNode1
+    extends StatsSampleSingleMasterSpec
+class StatsSampleSingleMasterSpecMultiJvmNode2
+    extends StatsSampleSingleMasterSpec
+class StatsSampleSingleMasterSpecMultiJvmNode3
+    extends StatsSampleSingleMasterSpec
 
-abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSingleMasterSpecConfig)
-  with WordSpecLike with Matchers with BeforeAndAfterAll with ImplicitSender {
+abstract class StatsSampleSingleMasterSpec
+    extends MultiNodeSpec(StatsSampleSingleMasterSpecConfig)
+    with AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ImplicitSender {
 
   import StatsSampleSingleMasterSpecConfig._
 
@@ -77,20 +72,20 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
       Cluster(system) join firstAddress
 
       receiveN(3).collect { case MemberUp(m) => m.address }.toSet should be(
-        Set(firstAddress, secondAddress, thirdAddress))
+        Set(firstAddress, secondAddress, thirdAddress)
+      )
 
       Cluster(system).unsubscribe(testActor)
 
-      val singletonSettings = ClusterSingletonSettings(typedSystem).withRole("compute")
+      val singletonSettings =
+        ClusterSingletonSettings(typedSystem).withRole("compute")
       singletonProxy = ClusterSingleton(typedSystem).init(
-        SingletonActor(
-          Behaviors.setup[StatsService.Command] { ctx =>
-            // just run some local workers for this test
-            val workersRouter = ctx.spawn(Routers.pool(2)(StatsWorker()), "WorkersRouter")
-            StatsService(workersRouter)
-          },
-          "StatsService",
-        ).withSettings(singletonSettings)
+        SingletonActor(Behaviors.setup[StatsService.Command] { ctx =>
+          // just run some local workers for this test
+          val workersRouter =
+            ctx.spawn(Routers.pool(2)(StatsWorker()), "WorkersRouter")
+          StatsService(workersRouter)
+        }, "StatsService", ).withSettings(singletonSettings)
       )
 
       testConductor.enter("all-up")
@@ -102,8 +97,12 @@ abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSing
       awaitAssert {
         system.log.info("Trying a request")
         val probe = TestProbe[StatsService.Response]()
-        singletonProxy ! StatsService.ProcessText("this is the text that will be analyzed", probe.ref)
-        val response = probe.expectMessageType[StatsService.JobResult](3.seconds)
+        singletonProxy ! StatsService.ProcessText(
+          "this is the text that will be analyzed",
+          probe.ref
+        )
+        val response =
+          probe.expectMessageType[StatsService.JobResult](3.seconds)
         response.meanWordLength should be(3.875 +- 0.001)
       }
 


### PR DESCRIPTION
Also:

 * Scala 2.13
 * sbt 1.3.9
 * Scalatest 3.1
 * Deprecated stream operators replaced
