### PR TITLE
Remove MDC from sample logs

### DIFF
--- a/akka-sample-cluster-java/src/main/resources/logback.xml
+++ b/akka-sample-cluster-java/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
         logging config, see the Akka docs: https://doc.akka.io/docs/akka/2.6/typed/logging.html#logback -->
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-cluster-scala/src/main/resources/logback.xml
+++ b/akka-sample-cluster-scala/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
         logging config, see the Akka docs: https://doc.akka.io/docs/akka/2.6/typed/logging.html#logback -->
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-cqrs-java/src/main/resources/logback.xml
+++ b/akka-sample-cqrs-java/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-cqrs-java/src/test/resources/logback-test.xml
+++ b/akka-sample-cqrs-java/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-cqrs-scala/src/main/resources/logback.xml
+++ b/akka-sample-cqrs-scala/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-cqrs-scala/src/test/resources/logback-test.xml
+++ b/akka-sample-cqrs-scala/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-distributed-data-java/src/main/resources/logback.xml
+++ b/akka-sample-distributed-data-java/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
   <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+      <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/akka-sample-distributed-data-java/src/test/resources/logback-test.xml
+++ b/akka-sample-distributed-data-java/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+      <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/akka-sample-distributed-data-scala/src/main/resources/logback.xml
+++ b/akka-sample-distributed-data-scala/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-distributed-data-scala/src/test/resources/logback-test.xml
+++ b/akka-sample-distributed-data-scala/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 
      <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
          <encoder>
-             <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+             <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
          </encoder>
      </appender>
 

--- a/akka-sample-fsm-java/src/main/resources/logback.xml
+++ b/akka-sample-fsm-java/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-fsm-scala/src/main/resources/logback.xml
+++ b/akka-sample-fsm-scala/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-persistence-dc-java/src/main/resources/logback.xml
+++ b/akka-sample-persistence-dc-java/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-persistence-dc-scala/src/main/resources/logback.xml
+++ b/akka-sample-persistence-dc-scala/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-persistence-java/src/main/resources/logback.xml
+++ b/akka-sample-persistence-java/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-persistence-java/src/test/resources/logback-test.xml
+++ b/akka-sample-persistence-java/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-persistence-scala/src/main/resources/logback.xml
+++ b/akka-sample-persistence-scala/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-sample-persistence-scala/src/test/resources/logback-test.xml
+++ b/akka-sample-persistence-scala/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
While we would like to get some extra publicity for the fact that
we publish useful MDC with the log entries it makes the sample logs
really hard to read.
