### PR TITLE
Use Akka's PersistenceInit.initializePlugins.

### DIFF
--- a/akka-sample-cqrs-java/pom.xml
+++ b/akka-sample-cqrs-java/pom.xml
@@ -94,6 +94,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-persistence-testkit_2.13</artifactId>
+      <version>${akka.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.lightbend.akka</groupId>
       <artifactId>akka-projection-testkit_2.13</artifactId>
       <version>${akka-projection.version}</version>

--- a/akka-sample-cqrs-scala/build.sbt
+++ b/akka-sample-cqrs-scala/build.sbt
@@ -25,6 +25,7 @@ lazy val `akka-sample-cqrs-scala` = project
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
         "ch.qos.logback" % "logback-classic" % "1.2.3",
         "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
+        "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
         "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
         "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
         "org.scalatest" %% "scalatest" % "3.1.0" % Test,


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka/pull/28809

The feature is released, therefore we can use PersistenceInit.initializePlugins or initializeDefaultPlugins.