### PR TITLE
Enable TravisCI for akka-sample-sharding-{ java, scala }

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ env:
     - CMD="cd akka-sample-persistence-dc-scala && sbt test"
     - CMD="cd akka-sample-cqrs-scala && sbt test"
     - CMD="cd akka-sample-cqrs-java && mvn test"
+    - CMD="cd akka-sample-sharding-java && mvn test"
+    - CMD="cd akka-sample-sharding-scala && sbt test"
     - CMD="cd docs-gen && sbt paradox"
     - CMD="cd akka-sample-kafka-to-sharding-scala && sbt test"
 script:

--- a/akka-sample-sharding-scala/killrweather/src/main/scala/sample/killrweather/WeatherStation.scala
+++ b/akka-sample-sharding-scala/killrweather/src/main/scala/sample/killrweather/WeatherStation.scala
@@ -112,7 +112,7 @@ private[killrweather] object WeatherStation {
 
       case Query(dataType, func, replyTo) =>
         val valuesForType = values.filter(_.dataType == dataType)
-        val queryResult: Seq[TimeWindow] =
+        val queryResult: Vector[TimeWindow] =
           if (valuesForType.isEmpty) Vector.empty
           else
             func match {


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
- Make `akka-sample-sharding-scala` compilable.
`akka-sample-sharding-scala` has the type mismatch compile error.
- Enable TravisCI for akka-sample-sharding-{ java, scala }.
These two subproject are not checked by TravisCI.