### PR TITLE
Dependencies that don't exist are not a security threat

### DIFF
--- a/akka-sample-fsm-java/pom.xml
+++ b/akka-sample-fsm-java/pom.xml
@@ -21,20 +21,9 @@
       <version>${akka.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-testkit_2.13</artifactId>
-      <version>${akka.version}</version>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.2.3</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This is in rsponse to a dependabot alert for junit 4.11 (which is unused on the affected sample).