### PR TITLE
Avoid accessing ActorContext inside Futures

### DIFF
--- a/akka-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserEventsKafkaProcessor.scala
+++ b/akka-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserEventsKafkaProcessor.scala
@@ -1,20 +1,26 @@
 package sample.sharding.kafka
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Try
+
 import akka.Done
+import akka.actor.Scheduler
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
-import akka.actor.typed.{ActorRef, Behavior}
-import akka.actor.{ActorSystem, Scheduler}
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.{ActorSystem => TypedActorSystem}
 import akka.kafka.cluster.sharding.KafkaClusterSharding
-import akka.kafka.scaladsl.{Committer, Consumer}
-import akka.kafka.{CommitterSettings, Subscriptions}
+import akka.kafka.scaladsl.Committer
+import akka.kafka.scaladsl.Consumer
+import akka.kafka.CommitterSettings
+import akka.kafka.Subscriptions
 import akka.pattern.retry
+import org.slf4j.LoggerFactory
 import sample.sharding.kafka.serialization.UserPurchaseProto
-
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.util.Try
 
 object UserEventsKafkaProcessor {
 
@@ -22,47 +28,16 @@ object UserEventsKafkaProcessor {
 
   private case class KafkaConsumerStopped(reason: Try[Any]) extends Command
 
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
   def apply(shardRegion: ActorRef[UserEvents.Command], processorSettings: ProcessorSettings): Behavior[Nothing] = {
     Behaviors
       .setup[Command] { ctx =>
-        implicit val classic: ActorSystem = ctx.system.toClassic
-        implicit val ec: ExecutionContextExecutor = ctx.executionContext
-        implicit val scheduler: Scheduler = classic.scheduler
+        implicit val sys: TypedActorSystem[_] = ctx.system
+        val result = consumeFromTopic(shardRegion, processorSettings)
 
-        // ActorContext can't be accessed inside Futures
-        // so we capture the scheduler and log before using them
-        val typedScheduler = ctx.system.scheduler
-        val logger = ctx.log
-
-        val rebalanceListener = KafkaClusterSharding(classic).rebalanceListener(processorSettings.entityTypeKey)
-
-        val subscription = Subscriptions
-          .topics(processorSettings.topics: _*)
-          .withRebalanceListener(rebalanceListener.toClassic)
-
-        val stream: Future[Done] =
-          Consumer.sourceWithOffsetContext(processorSettings.kafkaConsumerSettings(), subscription)
-            // MapAsync and Retries can be replaced by reliable delivery
-            .mapAsync(20) { record =>
-              logger.info(s"user id consumed kafka partition ${record.key()}->${record.partition()}")
-              retry(() =>
-                shardRegion.ask[Done](replyTo => {
-                  val purchaseProto = UserPurchaseProto.parseFrom(record.value())
-                  UserEvents.UserPurchase(
-                    purchaseProto.userId,
-                    purchaseProto.product,
-                    purchaseProto.quantity,
-                    purchaseProto.price,
-                    replyTo)
-                })(processorSettings.askTimeout, typedScheduler),
-                attempts = 5,
-                delay = 1.second
-              )
-            }
-            .runWith(Committer.sinkWithOffsetContext(CommitterSettings(classic)))
-
-        stream.onComplete { result =>
-          ctx.self ! KafkaConsumerStopped(result)
+        ctx.pipeToSelf(result) {
+          result => KafkaConsumerStopped(result)
         }
 
         Behaviors.receiveMessage[Command] {
@@ -75,4 +50,38 @@ object UserEventsKafkaProcessor {
   }
 
 
+  private def consumeFromTopic(shardRegion: ActorRef[UserEvents.Command], processorSettings: ProcessorSettings)
+                     (implicit actorSystem: TypedActorSystem[_]): Future[Done] = {
+
+    implicit val ec: ExecutionContext = actorSystem.executionContext
+    implicit val scheduler: Scheduler = actorSystem.toClassic.scheduler
+    val classic = actorSystem.toClassic
+
+    val rebalanceListener = KafkaClusterSharding(classic).rebalanceListener(processorSettings.entityTypeKey)
+
+    val subscription = Subscriptions
+      .topics(processorSettings.topics: _*)
+      .withRebalanceListener(rebalanceListener.toClassic)
+
+
+    Consumer.sourceWithOffsetContext(processorSettings.kafkaConsumerSettings(), subscription)
+      // MapAsync and Retries can be replaced by reliable delivery
+      .mapAsync(20) { record =>
+        logger.info(s"user id consumed kafka partition ${record.key()}->${record.partition()}")
+        retry(() =>
+          shardRegion.ask[Done](replyTo => {
+            val purchaseProto = UserPurchaseProto.parseFrom(record.value())
+            UserEvents.UserPurchase(
+              purchaseProto.userId,
+              purchaseProto.product,
+              purchaseProto.quantity,
+              purchaseProto.price,
+              replyTo)
+          })(processorSettings.askTimeout, actorSystem.scheduler),
+          attempts = 5,
+          delay = 1.second
+        )
+      }
+      .runWith(Committer.sinkWithOffsetContext(CommitterSettings(classic)))
+  }
 }

--- a/akka-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserEventsKafkaProcessor.scala
+++ b/akka-sample-kafka-to-sharding-scala/processor/src/main/scala/sample/sharding/kafka/UserEventsKafkaProcessor.scala
@@ -34,7 +34,7 @@ object UserEventsKafkaProcessor {
     Behaviors
       .setup[Command] { ctx =>
         implicit val sys: TypedActorSystem[_] = ctx.system
-        val result = consumeFromTopic(shardRegion, processorSettings)
+        val result = startConsumingFromTopic(shardRegion, processorSettings)
 
         ctx.pipeToSelf(result) {
           result => KafkaConsumerStopped(result)
@@ -50,7 +50,7 @@ object UserEventsKafkaProcessor {
   }
 
 
-  private def consumeFromTopic(shardRegion: ActorRef[UserEvents.Command], processorSettings: ProcessorSettings)
+  private def startConsumingFromTopic(shardRegion: ActorRef[UserEvents.Command], processorSettings: ProcessorSettings)
                      (implicit actorSystem: TypedActorSystem[_]): Future[Done] = {
 
     implicit val ec: ExecutionContext = actorSystem.executionContext


### PR DESCRIPTION
I run into it while experimenting with `KafkaClusterSharding`. 

As a side note, I think we should improve how we report access of ActorContext. It was not immediately obvious where the problem was. 