### PR TITLE
Fix wrong path

### DIFF
--- a/akka-sample-sharding-scala/README.md
+++ b/akka-sample-sharding-scala/README.md
@@ -154,7 +154,8 @@ With the cluster running you can interact with the HTTP endpoint using raw HTTP,
 Record data for station 62:
 
 ```
-curl -XPOST http://localhost:12553/weather/62/data -H "Content-Type: application/json" --data '{"eventTime": 1579106781, "dataType": "temperature", "value": 10.3}'
+curl -XPOST http://localhost:12553/weather/62
+-H "Content-Type: application/json" --data '{"eventTime": 1579106781, "dataType": "temperature", "value": 10.3}'
 ```
 
 Query average temperature for station 62:


### PR DESCRIPTION
It seems there is no `/data` part of the POST url: https://github.com/akka/akka-samples/blob/2.6/akka-sample-sharding-scala/killrweather/src/main/scala/sample/killrweather/WeatherRoutes.scala#L56-L62
