### PR TITLE
fix: Killrweather app was left at Akka 2.6.1

### DIFF
--- a/akka-sample-sharding-java/killrweather/pom.xml
+++ b/akka-sample-sharding-java/killrweather/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <akka.version>2.6.1</akka.version>
+        <akka.version>2.6.19</akka.version>
         <akka-http.version>10.1.11</akka-http.version>
     </properties>
 


### PR DESCRIPTION
References #256
