### PR TITLE
fix: Fork run and allow ctrl+c cancel

### DIFF
--- a/akka-sample-cluster-client-grpc-scala/build.sbt
+++ b/akka-sample-cluster-client-grpc-scala/build.sbt
@@ -30,6 +30,7 @@ lazy val `akka-sample-cluster-client-grpc-scala` = project
       "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % Test,
       "org.scalatest" %% "scalatest" % ScalaTestVersion % Test
-    )
+    ),
+    run / fork := true
   )
   .configs(MultiJvm)

--- a/akka-sample-cluster-java/build.sbt
+++ b/akka-sample-cluster-java/build.sbt
@@ -24,8 +24,7 @@ lazy val `akka-sample-cluster-java` = project
       "com.typesafe.akka" %% "akka-multi-node-testkit"    % AkkaVersion % Test,
       "org.scalatest"     %% "scalatest"                  % ScalaTestVersion % Test,
       "com.typesafe.akka" %% "akka-actor-testkit-typed"   % AkkaVersion % Test),
-    run / fork := false,
-    Global / cancelable := false,
+    run / fork := true,
     // disable parallel tests
     Test / parallelExecution := false,
     licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))

--- a/akka-sample-cluster-scala/build.sbt
+++ b/akka-sample-cluster-scala/build.sbt
@@ -24,8 +24,7 @@ lazy val `akka-sample-cluster-scala` = project
       "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % Test,
       "org.scalatest"     %% "scalatest" % ScalaTestVersion % Test,
       "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test),
-    run / fork := false,
-    Global / cancelable := false,
+    run / fork := true,
     // disable parallel tests
     Test / parallelExecution := false,
     licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))

--- a/akka-sample-distributed-data-java/build.sbt
+++ b/akka-sample-distributed-data-java/build.sbt
@@ -25,7 +25,6 @@ val `akka-sample-distributed-data-java` = project
       "ch.qos.logback" % "logback-classic" % LogbackClassicVersion % Test,
       "org.scalatest" %% "scalatest" % ScalaTestVersion % Test),
     fork in run := true,
-    Global / cancelable := false, // ctrl-c
     // disable parallel tests
     parallelExecution in Test := false,
     // show full stack traces and test case durations

--- a/akka-sample-distributed-data-scala/build.sbt
+++ b/akka-sample-distributed-data-scala/build.sbt
@@ -25,7 +25,6 @@ val `akka-sample-distributed-data-scala` = project
       "ch.qos.logback" % "logback-classic" % LogbackClassicVersion % Test,
       "org.scalatest" %% "scalatest" % ScalaTestVersion % Test),
     fork in run := true,
-    Global / cancelable := false, // ctrl-c
     // disable parallel tests
     parallelExecution in Test := false,
     // show full stack traces and test case durations

--- a/akka-sample-distributed-workers-scala/build.sbt
+++ b/akka-sample-distributed-workers-scala/build.sbt
@@ -10,7 +10,7 @@ val LogbackClassicVersion = "1.2.11"
 val ScalaTestVersion = "3.1.1"
 val CommonIoVersion = "2.4"
 
-Global / cancelable := false
+run / fork := true
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,

--- a/akka-sample-fsm-scala/build.sbt
+++ b/akka-sample-fsm-scala/build.sbt
@@ -12,6 +12,8 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion
 )
 
+run / fork := true
+
 licenses := Seq(
   ("CC0", url("http://creativecommons.org/publicdomain/zero/1.0"))
 )

--- a/akka-sample-kafka-to-sharding-scala/build.sbt
+++ b/akka-sample-kafka-to-sharding-scala/build.sbt
@@ -21,7 +21,7 @@ ThisBuild / resolvers ++= Seq(
   Resolver.bintrayRepo("akka", "snapshots")
 )
 
-Global / cancelable := true // ctrl-c
+run / fork := true
 
 lazy val `akka-sample-kafka-to-sharding` = project.in(file(".")).aggregate(producer, processor, client)
 

--- a/akka-sample-persistence-dc-scala/build.sbt
+++ b/akka-sample-persistence-dc-scala/build.sbt
@@ -39,4 +39,6 @@ dependencyOverrides += "com.typesafe.akka" %% "akka-protobuf" % AkkaVersion
 dependencyOverrides += "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion
 dependencyOverrides += "com.typesafe.akka" %% "akka-coordination" % AkkaVersion
 
+run / fork := true
+
 licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))

--- a/akka-sample-persistence-scala/build.sbt
+++ b/akka-sample-persistence-scala/build.sbt
@@ -22,4 +22,6 @@ scalacOptions in Compile ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlo
 testOptions in Test += Tests.Argument("-oDF")
 logBuffered in Test := false
 
+run / fork := true
+
 licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))

--- a/akka-sample-sharding-java/build.sbt
+++ b/akka-sample-sharding-java/build.sbt
@@ -16,8 +16,7 @@ lazy val commonJavacOptions = Seq(
 lazy val commonSettings = Seq(
   Compile / javacOptions ++= commonJavacOptions,
   run / javaOptions ++= Seq("-Xms128m", "-Xmx1024m"),
-  run / fork := false,
-  Global / cancelable := false,
+  run / fork := true,
   licenses := Seq(
     ("CC0", url("http://creativecommons.org/publicdomain/zero/1.0"))
   )

--- a/akka-sample-sharding-scala/build.sbt
+++ b/akka-sample-sharding-scala/build.sbt
@@ -24,8 +24,7 @@ lazy val commonSettings = Seq(
   Compile / scalacOptions ++= commonScalacOptions,
   Compile / javacOptions ++= commonJavacOptions,
   run / javaOptions ++= Seq("-Xms128m", "-Xmx1024m"),
-  run / fork := false,
-  Global / cancelable := false,
+  run / fork := true,
   licenses := Seq(
     ("CC0", url("http://creativecommons.org/publicdomain/zero/1.0"))
   )


### PR DESCRIPTION
With sbt 1.6.0+ in-process run exits once main exits, which breaks all samples. Run them forked instead so that it works, also allow ctrl+c to kill just the forked process, not sbt itself.
