### PR TITLE
fix: Wrong instruction on how to run for replicated eventsourcing sample

### DIFF
--- a/akka-sample-persistence-dc-java/README.md
+++ b/akka-sample-persistence-dc-java/README.md
@@ -4,11 +4,11 @@ akka-sample-persistence-dc-java
 ## How to run
 
 1. Setup Cassandra
-   * Either start a local Cassnadsra listening on port 9042 or in terminal 1: `mvn exec:java -Dexec.mainClass="sample.persistence.multidc.ThumbsUpApp" -Dexec.args="cassandra"`
+   * Either start a local Cassnadsra listening on port 9042 or in terminal 1: `mvn exec:java -Dexec.mainClass="sample.persistence.res.MainApp" -Dexec.args="cassandra"`
 
-1. In terminal 2: `mvn compile exec:java -Dexec.mainClass="sample.persistence.multidc.ThumbsUpApp" -Dexec.args="2551 eu-west"`
+1. In terminal 2: `mvn compile exec:java -Dexec.mainClass="sample.persistence.res.MainApp" -Dexec.args="2551 eu-west"`
 
-1. In terminal 3: `mvn compile exec:java -Dexec.mainClass="sample.persistence.multidc.ThumbsUpApp" -Dexec.args="2552 eu-central"`
+1. In terminal 3: `mvn compile exec:java -Dexec.mainClass="sample.persistence.res.MainApp" -Dexec.args="2552 eu-central"`
 
 1. In terminal 4:
     * To add a thumbs-up for resource `akka` from user `u1` in DC `eu-west`: `curl -X POST http://127.0.0.1:22551/thumbs-up/akka/u1`

--- a/akka-sample-persistence-dc-scala/README.md
+++ b/akka-sample-persistence-dc-scala/README.md
@@ -6,11 +6,11 @@ to run a replica per datacenter.
 
 ## How to run
 
-1. In terminal 1: `sbt "runMain sample.persistence.multidc.ThumbsUpApp cassandra"`
+1. In terminal 1: `sbt "run cassandra"`
 
-1. In terminal 2: `sbt "runMain sample.persistence.multidc.ThumbsUpApp 2551 eu-west"`
+1. In terminal 2: `sbt "run 2551 eu-west"`
 
-1. In terminal 3: `sbt "runMain sample.persistence.multidc.ThumbsUpApp 2552 eu-central"`
+1. In terminal 3: `sbt "run 2552 eu-central"`
 
 1. In terminal 4:
     * To add a thumbs-up for resource `akka` from user `u1` in DC `eu-west`: `curl -X POST http://127.0.0.1:22551/thumbs-up/akka/u1`


### PR DESCRIPTION
Once projections 1.4.0 is out we should probably drop these samples entirely since we have RES samples with gRPC transport in there.

Refs #275