### PR TITLE
Removed unnecessary httpPort parameter from WeatherStation#running(...).

### DIFF
--- a/akka-sample-sharding-scala/killrweather-fog/src/main/scala/sample/killrweather/fog/WeatherStation.scala
+++ b/akka-sample-sharding-scala/killrweather-fog/src/main/scala/sample/killrweather/fog/WeatherStation.scala
@@ -37,7 +37,7 @@ private[fog] object WeatherStation {
   /** Starts a device and it's task to initiate reading data at a scheduled rate. */
   def apply(wsid: WeatherStationId, settings: FogSettings, httpPort: Int): Behavior[Command] =
     Behaviors.setup(ctx =>
-      new WeatherStation(ctx, wsid, settings, httpPort).running(httpPort)
+      new WeatherStation(ctx, wsid, settings, httpPort).running
     )
 }
 
@@ -53,7 +53,7 @@ private class WeatherStation(context: ActorContext[WeatherStation.Command], wsid
   }
   private val stationUrl = s"http://${settings.host}:${httpPort}/weather/$wsid"
 
-  def running(httpPort: Int): Behavior[WeatherStation.Command] = {
+  val running: Behavior[WeatherStation.Command] = {
     context.log.infoN(s"Started WeatherStation {} of total {} with weather port {}",
       wsid, settings.weatherStations, httpPort)
 

--- a/akka-sample-sharding-scala/killrweather-fog/src/main/scala/sample/killrweather/fog/WeatherStation.scala
+++ b/akka-sample-sharding-scala/killrweather-fog/src/main/scala/sample/killrweather/fog/WeatherStation.scala
@@ -53,7 +53,7 @@ private class WeatherStation(context: ActorContext[WeatherStation.Command], wsid
   }
   private val stationUrl = s"http://${settings.host}:${httpPort}/weather/$wsid"
 
-  val running: Behavior[WeatherStation.Command] = {
+  def running: Behavior[WeatherStation.Command] = {
     context.log.infoN(s"Started WeatherStation {} of total {} with weather port {}",
       wsid, settings.weatherStations, httpPort)
 


### PR DESCRIPTION
Removed `httpPort` from `running(httpPort)`, since it appears we'd never pass in a different `httpPort` than the one on the class anyway, and the one passed into the method is only used for logging?

This made the example slightly confusing for me, as I had to try and understand if there's a reason for the additional parameter.